### PR TITLE
Add number of episodes to contentDto for series

### DIFF
--- a/src/main/java/com/umc/sp/contents/dto/response/ContentSeriesDetailDto.java
+++ b/src/main/java/com/umc/sp/contents/dto/response/ContentSeriesDetailDto.java
@@ -1,0 +1,14 @@
+package com.umc.sp.contents.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentSeriesDetailDto extends ContentDetailDto{
+    private int episodes;
+}

--- a/src/main/java/com/umc/sp/contents/dto/response/ContentSeriesDto.java
+++ b/src/main/java/com/umc/sp/contents/dto/response/ContentSeriesDto.java
@@ -1,0 +1,14 @@
+package com.umc.sp.contents.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentSeriesDto extends ContentDto {
+    private int episodes;
+}

--- a/src/main/java/com/umc/sp/contents/persistence/model/ContentGroup.java
+++ b/src/main/java/com/umc/sp/contents/persistence/model/ContentGroup.java
@@ -1,11 +1,17 @@
 package com.umc.sp.contents.persistence.model;
 
+import com.umc.sp.contents.persistence.model.custom.ContentCountByParentId;
 import com.umc.sp.contents.persistence.model.id.ContentGroupId;
 import jakarta.persistence.Column;
+import jakarta.persistence.ColumnResult;
+import jakarta.persistence.ConstructorResult;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.SqlResultSetMapping;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,6 +23,16 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @Entity
 @Table(name = "content_groups")
+@NamedNativeQuery(name = "getChildContentCountByParentContentIds", query = """
+           SELECT count(content_id) AS child_content_count, parent_content_id
+           FROM content_groups
+           WHERE  parent_content_id IN (:contentIds)
+           AND disabled_date IS NULL
+           GROUP BY parent_content_id
+        """, resultSetMapping = "getChildContentCountByParentContentIdsMapping")
+@SqlResultSetMapping(name = "getChildContentCountByParentContentIdsMapping", classes = @ConstructorResult(targetClass = ContentCountByParentId.class, columns = {
+        @ColumnResult(name = "child_content_count", type = Integer.class), @ColumnResult(name = "parent_content_id", type = UUID.class)
+}))
 public class ContentGroup {
 
     @EmbeddedId

--- a/src/main/java/com/umc/sp/contents/persistence/model/custom/ContentCountByParentId.java
+++ b/src/main/java/com/umc/sp/contents/persistence/model/custom/ContentCountByParentId.java
@@ -1,0 +1,16 @@
+package com.umc.sp.contents.persistence.model.custom;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ContentCountByParentId {
+    private Integer childContentCount;
+    private UUID parentContentId;
+}

--- a/src/main/java/com/umc/sp/contents/persistence/repository/ContentGroupRepository.java
+++ b/src/main/java/com/umc/sp/contents/persistence/repository/ContentGroupRepository.java
@@ -1,7 +1,9 @@
 package com.umc.sp.contents.persistence.repository;
 
 import com.umc.sp.contents.persistence.model.ContentGroup;
+import com.umc.sp.contents.persistence.model.custom.ContentCountByParentId;
 import com.umc.sp.contents.persistence.model.id.ContentGroupId;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -14,7 +16,11 @@ public interface ContentGroupRepository extends JpaRepository<ContentGroup, Cont
 
     List<ContentGroup> findByIdContentId(UUID contentId);
 
-    List<ContentGroup> findAllByIdContentIdIn(Set<UUID> contentId);
+    List<ContentGroup> findAllByIdContentIdIn(Set<UUID> contentIds);
+
+    @Query(name = "getChildContentCountByParentContentIds", nativeQuery = true)
+    List<ContentCountByParentId> getChildContentCountByParentContentIds(@Param("contentIds") Set<UUID> contentIds);
+
 
     @Query(value = """
             SELECT NOT EXISTS (

--- a/src/test/java/com/umc/sp/contents/persistence/repository/ContentGroupsRepositoryIntegrationTest.java
+++ b/src/test/java/com/umc/sp/contents/persistence/repository/ContentGroupsRepositoryIntegrationTest.java
@@ -1,10 +1,12 @@
 package com.umc.sp.contents.persistence.repository;
 
 import com.umc.sp.contents.IntegrationTest;
+import com.umc.sp.contents.persistence.model.custom.ContentCountByParentId;
 import com.umc.sp.contents.persistence.model.type.ContentStructureType;
 import com.umc.sp.contents.persistence.model.type.ContentType;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -121,6 +123,27 @@ public class ContentGroupsRepositoryIntegrationTest implements IntegrationTest {
 
         //then
         assertThat(result).isTrue();
+    }
+
+
+    @Test
+    void shouldGetChildContentCountByParentContentIds() {
+        //given
+        var category = categoriesRepository.save(buildCategory().build());
+        var genre = genresRepository.save(buildGenre().build());
+        var parentContent = contentRepository.save(buildContent(category, genre).type(ContentType.SERIES).structureType(ContentStructureType.GROUP).build());
+        var content = contentRepository.save(buildContent(category, genre).build());
+        var content2 = contentRepository.save(buildContent(category, genre).build());
+        var content3 = contentRepository.save(buildContent(category, genre).build());
+        var contentGroup = contentGroupRepository.save(buildContentGroup(parentContent, content).disabledDate(LocalDateTime.now(clock)).build());
+        var contentGroup2 = contentGroupRepository.save(buildContentGroup(parentContent, content2).build());
+        var contentGroup3 = contentGroupRepository.save(buildContentGroup(parentContent, content3).build());
+
+        //when
+        var result = contentGroupRepository.getChildContentCountByParentContentIds(Set.of(parentContent.getId().getId()));
+
+        //then
+        assertThat(result).containsExactlyInAnyOrder(new ContentCountByParentId(2,parentContent.getId().getId()));
     }
 
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -17,7 +17,13 @@ content.assets.videos.url = https://test/assets/videos/%s/images/
 content.assets.series.url = https://test/assets/series/%s/images/
 content.assets.experts.url = https://test/assets/experts/%s/images/
 
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
-logging.level.org.hibernate.SQL=DEBUG
-logging.level.org.hibernate.type.descriptor.sql=TRACE
+#spring.jpa.show-sql=true
+#spring.jpa.properties.hibernate.format_sql=true
+#logging.level.org.hibernate.SQL=DEBUG
+#logging.level.org.hibernate.type.descriptor.sql=TRACE
+
+logging.level.reactor.netty.http.client=DEBUG
+
+
+logging.level.org.springframework.web.reactive.function.client.ExchangeFunctions: DEBUG
+logging.level.org.springframework.web.reactive.function.client.ExchangeFilterFunction: DEBUG


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Series content details and listings now display the number of episodes.
  * Episode counts for series are dynamically retrieved and shown in relevant sections.

* **Bug Fixes**
  * Improved accuracy in displaying episode counts by excluding disabled child content.

* **Tests**
  * Added and updated integration tests to verify correct episode counting and JSON response structure.

* **Chores**
  * Updated logging configuration to focus on HTTP client interactions instead of SQL logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->